### PR TITLE
Fix: Update @modelcontextprotocol/inspector to a valid version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
-    "@modelcontextprotocol/inspector": "^1.0.0",
+    "@modelcontextprotocol/inspector": "^0.10.2",
     "@types/node": "^20.11.19",
     "concurrently": "^9.1.2",
     "nodemon": "^3.1.9",


### PR DESCRIPTION
This PR fixes an installation error caused by an invalid version specification for the @modelcontextprotocol/inspector package.

### Problem
The package.json was specifying version `^1.0.0` for @modelcontextprotocol/inspector, which doesn't exist in the npm registry, causing the following error during installation:

```
npm error code ETARGET
npm error notarget No matching version found for @modelcontextprotocol/inspector@^1.0.0.
npm error notarget In most cases you or one of your dependencies are requesting
npm error notarget a package version that doesn't exist.
```

### Solution
Updated the dependency to version `^0.10.2`, which is available in the npm registry and resolves the installation error.

### Changes
- Updated @modelcontextprotocol/inspector from `^1.0.0` to `^0.10.2` in package.json

### Testing
- Verified that `npm install` completes successfully with the updated version